### PR TITLE
Make copyrights consistent

### DIFF
--- a/.azurepipelines/PrGate.yml
+++ b/.azurepipelines/PrGate.yml
@@ -1,7 +1,8 @@
 ## @file
 # Azure Pipeline build file for the repository
 #
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
 ##
 
 trigger: none

--- a/.azurepipelines/templates/Build.yml
+++ b/.azurepipelines/templates/Build.yml
@@ -1,7 +1,8 @@
 #
 # Azure pipeline template for build.
 #
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
 ##
 
 jobs:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -3,7 +3,7 @@
 # markdownlint configuration file
 #
 ##
-# Copyright (c) Microsoft Corporation
+# Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0
 ##
 {

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/common/src/serializable_fv.rs
+++ b/common/src/serializable_fv.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/common/src/serializable_hob.rs
+++ b/common/src/serializable_hob.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/dxe_readiness_capture/src/allocator.rs
+++ b/dxe_readiness_capture/src/allocator.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/dxe_readiness_capture/src/bin/intel_dxe_readiness_capture.rs
+++ b/dxe_readiness_capture/src/bin/intel_dxe_readiness_capture.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/dxe_readiness_capture/src/bin/qemu_dxe_readiness_capture.rs
+++ b/dxe_readiness_capture/src/bin/qemu_dxe_readiness_capture.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/dxe_readiness_capture/src/bin/uefishell_dxe_readiness_capture.rs
+++ b/dxe_readiness_capture/src/bin/uefishell_dxe_readiness_capture.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/dxe_readiness_capture/src/capture.rs
+++ b/dxe_readiness_capture/src/capture.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/dxe_readiness_capture/src/capture/fv.rs
+++ b/dxe_readiness_capture/src/capture/fv.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/dxe_readiness_capture/src/capture/hob.rs
+++ b/dxe_readiness_capture/src/capture/hob.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/dxe_readiness_capture/src/lib.rs
+++ b/dxe_readiness_capture/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/dxe_readiness_validator/src/commandline.rs
+++ b/dxe_readiness_validator/src/commandline.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/dxe_readiness_validator/src/errors.rs
+++ b/dxe_readiness_validator/src/errors.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/dxe_readiness_validator/src/logger.rs
+++ b/dxe_readiness_validator/src/logger.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/dxe_readiness_validator/src/main.rs
+++ b/dxe_readiness_validator/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/dxe_readiness_validator/src/validate.rs
+++ b/dxe_readiness_validator/src/validate.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/dxe_readiness_validator/src/validate/fv.rs
+++ b/dxe_readiness_validator/src/validate/fv.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/dxe_readiness_validator/src/validate/hob.rs
+++ b/dxe_readiness_validator/src/validate/hob.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/dxe_readiness_validator/src/validation_kind.rs
+++ b/dxe_readiness_validator/src/validation_kind.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/dxe_readiness_validator/src/validation_report.rs
+++ b/dxe_readiness_validator/src/validation_report.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/dxe_readiness_validator/src/validator.rs
+++ b/dxe_readiness_validator/src/validator.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!


### PR DESCRIPTION
Files had been added to the repo with a mix of Microsoft copyright format. The correct format is:

> "Copyright (c) Microsoft Corporation."

Unrelated to the change, but the SPDX identifier is used so tools like GitHub license detection can parse the license.