### PR TITLE
Re-enable cargo-deny

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,22 +43,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "goblin",
  "patina",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "dxe_readiness_capture"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cfg-if",
  "common",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "dxe_readiness_validator"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "colored",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "patina"
-version = "14.3.2"
+version = "14.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b61a1f3faf9f6891326d8221df9d89e125a370b219549abe6ae2b0d3a8c3cd"
+checksum = "21f0e70aac0830f24e3b0cd4dc697fcff53aa625336ee07ad419e9c36cb9d335"
 dependencies = [
  "cfg-if",
  "fallible-streaming-iterator",
@@ -487,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "patina_macro"
-version = "14.3.2"
+version = "14.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf1a92cdc2283e31ba038871c6141f09c19b53620509257a21b22523a2491a80"
+checksum = "aa7527737605af7494e14ca114e8be71cb5483e3a0dae4551a8edf6aa01b40f2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -499,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "patina_stacktrace"
-version = "14.3.2"
+version = "14.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc7367d91d160bf15a6714afdb77527d81ed3536c63893a0f46023772029cf7f"
+checksum = "839efa87dd31b55cf5cb5419d2f06be457462cf29b19986ea7b75055ddb92fb8"
 dependencies = [
  "cfg-if",
  "log",
@@ -707,9 +707,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.109"
+version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f17c7e013e88258aa9543dcbe81aca68a667a9ac37cd69c9fbc07858bfe0e2f"
+checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -861,16 +861,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -888,31 +879,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -922,22 +896,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -946,22 +908,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -970,22 +920,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -994,22 +932,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.85"
 description = "Dxe Readiness Capture/Validation Tool"
+repository = "https://github.com/OpenDevicePartnership/patina-readiness-tool"
 
 [workspace.dependencies]
 cfg-if = "1.0.4"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -140,8 +140,11 @@ description = "Run cspell for spell checking."                                  
 script = "cspell --quiet  --no-progress --no-summary  --dot --gitignore -e \"{.git/**,.github/**,.vscode/**,.azurepipelines/**,dxe_readiness_validator/src/tests/data/*.json}\" ."
 
 [tasks.deny]
-description = "Run cargo deny (disabled)."
-disabled = true
+description = "Run cargo deny."
+install_crate = false
+clear = true
+command = "cargo"
+args = ["deny", "check"]
 
 [tasks.all]
 description = "Run all tasks for PR readiness."

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "common"
-version = "0.1.0"
 edition = "2021"
+version.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 goblin = { workspace = true, features = ["pe32", "pe64", "te", "alloc"]}

--- a/deny.toml
+++ b/deny.toml
@@ -59,9 +59,6 @@ ignore = [
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
-
-    # Note: `paste` is currently used in `gdbstub` brought in by `patina_debugger`
-    { id = "RUSTSEC-2024-0436", reason = "Macros for token pasting. No longer maintained per readme. Consider alternatives." },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.
@@ -92,9 +89,9 @@ exceptions = [
     # Each entry is the crate and version constraint, and its specific allow
     # list
     #{ allow = ["Zlib"], crate = "adler32" },
-    { allow = ["0BSD"], crate = "managed" },                # todo: follow up on crate license
-    { allow = ["BSD-3-Clause"], crate = "alloc-no-stdlib"}, # todo: follow up on crate license (via brotli-decompressor)
     { allow = ["Unicode-3.0"], crate = "unicode-ident" },   # todo: follow up on crate license
+    { allow = ["MPL-2.0"], crate = "colored" },   # todo: follow up on crate license
+    { allow = ["MPL-2.0"], crate = "ucs2" },   # todo: follow up on crate license
 ]
 
 [licenses.private]
@@ -173,7 +170,8 @@ skip = [
     #"ansi_term@0.11.0",
     #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
 
-    { crate = "bitflags", reason = "Need https://github.com/gz/rust-x86/pull/150 to be merged into rust-x86."}
+    { crate = "bitflags", reason = "Need https://github.com/gz/rust-x86/pull/150 to be merged into rust-x86."},
+    { crate = "windows-sys", reason = "https://crates.io/crates/colored latest (v3.0.0) uses 0.59. https://crates.io/crates/anstyle-query latest (v1.1.5) uses 0.61."},
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive

--- a/dxe_readiness_capture/Cargo.toml
+++ b/dxe_readiness_capture/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "dxe_readiness_capture"
-version = "0.1.0"
 edition = "2021"
+version.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 cfg-if = { workspace = true }

--- a/dxe_readiness_validator/Cargo.toml
+++ b/dxe_readiness_validator/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "dxe_readiness_validator"
-version = "0.1.0"
 edition = "2021"
+version.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 clap = { workspace = true }


### PR DESCRIPTION
## Description

Resolves #23 

This reverts commit 754d735fa9593e01c330836f555fe5c70b401629.

Makes the changes necessary for cargo-deny.

> deny.toml will be updated in patina-devops to be customized for this repo per the changes in this PR.

Also makes some minor updates in various crate Cargo.toml files to reference common config from the workspace Cargo.toml file.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make deny`

## Integration Instructions

- N/A