### PR TITLE
Add PEI Memory Bin Support [Rebase & FF]

### DIFF
--- a/dxe_readiness_validator/src/validate/hob.rs
+++ b/dxe_readiness_validator/src/validate/hob.rs
@@ -7,9 +7,10 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 use patina::{
+    OwnedGuid,
     base::UEFI_PAGE_SIZE,
     pi::{
-        hob::{EFI_RESOURCE_IO, EFI_RESOURCE_IO_RESERVED},
+        hob::{EFI_RESOURCE_IO, EFI_RESOURCE_IO_RESERVED, MEMORY_TYPE_INFO_HOB_GUID},
         serializable::{
             Interval,
             serializable_hob::{HobSerDe, ResourceDescriptorSerDe},
@@ -39,6 +40,12 @@ impl<'a> HobValidator<'a> {
 
     fn is_io(resource_type: u32) -> bool {
         resource_type == EFI_RESOURCE_IO || resource_type == EFI_RESOURCE_IO_RESERVED
+    }
+
+    /// Returns true when a resource descriptor HOB is owned by the Memory Type Information GUID
+    /// and therefore describes the PEI memory bin ranges.
+    fn is_memory_type_info(resource: &ResourceDescriptorSerDe) -> bool {
+        OwnedGuid::try_from_string(&resource.owner).is_ok_and(|owner| owner == MEMORY_TYPE_INFO_HOB_GUID)
     }
 
     fn check_hob_overlap<'b, T>(resource_list: &[&'b T]) -> Vec<(&'b T, &'b T)>
@@ -100,8 +107,13 @@ impl<'a> HobValidator<'a> {
     }
 
     /// Checks for inconsistencies between overlapping V1 and V2 resource
-    /// descriptor HOBs. Reports violations when attributes like resource type,
-    /// attribute, or owner differ.
+    /// descriptor HOBs. Reports violations when `resource_type` or
+    /// `resource_attribute` differ between V1 and V2 descriptors that cover
+    /// overlapping ranges.
+    ///
+    /// Resource descriptors whose `owner` is `MEMORY_TYPE_INFO_HOB_GUID` are
+    /// skipped because the PEI memory bin HOB is expected to overlap with the
+    /// resource descriptors describing the system memory backing those bins.
     ///
     /// For v1/v2, The requirement is that v2 hobs are a superset of v1 Below is
     /// the strategy use:
@@ -122,10 +134,11 @@ impl<'a> HobValidator<'a> {
             for hob2 in self.hob_list {
                 let HobSerDe::ResourceDescriptor(v1) = hob1 else { continue };
                 let HobSerDe::ResourceDescriptorV2 { v1: v2, .. } = hob2 else { continue };
+                if Self::is_memory_type_info(v1) || Self::is_memory_type_info(v2) {
+                    continue;
+                }
                 if v1.overlaps(v2)
-                    && (v1.resource_type != v2.resource_type
-                        || v1.resource_attribute != v2.resource_attribute
-                        || v1.owner != v2.owner)
+                    && (v1.resource_type != v2.resource_type || v1.resource_attribute != v2.resource_attribute)
                 {
                     inconsistent_v1_v2.push((v1, v2));
                 }
@@ -142,6 +155,9 @@ impl<'a> HobValidator<'a> {
 
     /// Checks that all V1 resource descriptors are covered by V2 descriptors,
     /// reporting any V1 ranges not migrated to V2.
+    ///
+    /// Resource descriptors whose `owner` is `MEMORY_TYPE_INFO_HOB_GUID` are
+    /// skipped as the HOB describes PEI memory bins overlaying system memory.
     fn validate_v1v2_superset(&self) -> ValidationResult<'_> {
         let mut validation_report = ValidationReport::new();
         let mut v1_resources: Vec<&ResourceDescriptorSerDe> = Vec::new();
@@ -151,6 +167,9 @@ impl<'a> HobValidator<'a> {
 
         for hob in self.hob_list {
             if let HobSerDe::ResourceDescriptor(v1) = hob {
+                if Self::is_memory_type_info(v1) {
+                    continue;
+                }
                 v1_resources.push(v1);
             } else if let HobSerDe::ResourceDescriptorV2 { v1: v2, .. } = hob {
                 v2_resources.push(v2);
@@ -559,5 +578,108 @@ mod tests {
         assert!(result.is_ok());
         let validation_report = result.unwrap();
         assert_ne!(validation_report.violation_count(), 0);
+    }
+
+    /// String form of `MEMORY_TYPE_INFO_HOB_GUID` used for tests.
+    fn mem_info_owner() -> String {
+        MEMORY_TYPE_INFO_HOB_GUID.as_guid().to_string()
+    }
+
+    /// String form of `OwnedGuid::ZERO` used for tests.
+    fn zero_owner() -> String {
+        OwnedGuid::ZERO.to_string()
+    }
+
+    /// Test that a V1 resource descriptor HOB owned by `MEMORY_TYPE_INFO_HOB_GUID`
+    /// that overlaps a V2 system memory range with different `resource_attribute`
+    /// does not get flagged.
+    #[test]
+    fn test_memory_type_info_v1_overlap_with_v2_is_not_flagged() {
+        let v1 = create_v1_hob(0x7e233000, 0xdbb000, 0, 0x7, &mem_info_owner());
+        let v2 = create_v2_hob(0x100000, 0x7ef00000, 0, 0x3c07, &zero_owner(), 0);
+        let hob_list = vec![v1, v2];
+
+        let validator = HobValidator::new(&hob_list);
+        let result = validator.validate_overlapping_v1v2_attributes();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().violation_count(), 0);
+    }
+
+    /// Test that the `MEMORY_TYPE_INFO_HOB_GUID` skip is case-insensitive. A
+    /// captured owner string in uppercase (or mixed case) should match the same
+    /// well-known GUID and be skipped.
+    ///
+    /// Note: This test deliberately uses a hard-coded uppercase string (rather than
+    /// the SDK constant).
+    #[test]
+    fn test_memory_type_info_skip_is_case_insensitive() {
+        const MEM_INFO_OWNER_UPPER: &str = "4C19049F-4137-4DD3-9C10-8B97A83FFDFA";
+        let v1 = create_v1_hob(0x7e233000, 0xdbb000, 0, 0x7, MEM_INFO_OWNER_UPPER);
+        let v2 = create_v2_hob(0x100000, 0x7ef00000, 0, 0x3c07, &zero_owner(), 0);
+        let hob_list = vec![v1, v2];
+
+        let validator = HobValidator::new(&hob_list);
+        let result = validator.validate_overlapping_v1v2_attributes();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().violation_count(), 0);
+    }
+
+    /// Test that the skip relies on `OwnedGuid::try_from_string`, which tolerates
+    /// the no-dashes hex form. The same captured GUID without dashes should still
+    /// be recognized as `MEMORY_TYPE_INFO_HOB_GUID`.
+    #[test]
+    fn test_memory_type_info_skip_accepts_no_dashes() {
+        const MEM_INFO_OWNER_NO_DASHES: &str = "4c19049f41374dd39c108b97a83ffdfa";
+        let v1 = create_v1_hob(0x7e233000, 0xdbb000, 0, 0x7, MEM_INFO_OWNER_NO_DASHES);
+        let v2 = create_v2_hob(0x100000, 0x7ef00000, 0, 0x3c07, &zero_owner(), 0);
+        let hob_list = vec![v1, v2];
+
+        let validator = HobValidator::new(&hob_list);
+        let result = validator.validate_overlapping_v1v2_attributes();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().violation_count(), 0);
+    }
+
+    /// Test that a malformed owner string does not silently match `MEMORY_TYPE_INFO_HOB_GUID`.
+    #[test]
+    fn test_malformed_owner_does_not_match_memory_type_info() {
+        let v1 = create_v1_hob(0x100000, 0x10000, 0, 0x7, "not-a-guid");
+        let v2 = create_v2_hob(0x100000, 0x10000, 0, 0x3c07, &zero_owner(), 0);
+        let hob_list = vec![v1, v2];
+
+        let validator = HobValidator::new(&hob_list);
+        let result = validator.validate_overlapping_v1v2_attributes();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().violation_count(), 1);
+    }
+
+    /// An owner-only mismatch between overlapping V1 and V2 descriptors (with
+    /// identical `resource_type` and `resource_attribute`) is not a memory
+    /// attribute inconsistency and should not produce a violation.
+    #[test]
+    fn test_owner_only_mismatch_is_not_flagged() {
+        let v1 = create_v1_hob(0x100000, 0x10000, 0, 0x3c07, "owner-a");
+        let v2 = create_v2_hob(0x100000, 0x10000, 0, 0x3c07, "owner-b", 0);
+        let hob_list = vec![v1, v2];
+
+        let validator = HobValidator::new(&hob_list);
+        let result = validator.validate_overlapping_v1v2_attributes();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().violation_count(), 0);
+    }
+
+    /// Test that the V1/V2 attribute consistency check detects mismatches for
+    /// different attributes with a non-`MEMORY_TYPE_INFO_HOB_GUID` owner.
+    #[test]
+    fn test_non_memory_type_info_attribute_mismatch_is_still_flagged() {
+        // Same range, same owner, mismatched resource_attribute.
+        let v1 = create_v1_hob(0x100000, 0x10000, 0, 0x7, "owner-x");
+        let v2 = create_v2_hob(0x100000, 0x10000, 0, 0x3c07, "owner-x", 0);
+        let hob_list = vec![v1, v2];
+
+        let validator = HobValidator::new(&hob_list);
+        let result = validator.validate_overlapping_v1v2_attributes();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().violation_count(), 1);
     }
 }

--- a/dxe_readiness_validator/src/validate/hob.rs
+++ b/dxe_readiness_validator/src/validate/hob.rs
@@ -13,7 +13,7 @@ use patina::{
         hob::{EFI_RESOURCE_IO, EFI_RESOURCE_IO_RESERVED, MEMORY_TYPE_INFO_HOB_GUID},
         serializable::{
             Interval,
-            serializable_hob::{HobSerDe, ResourceDescriptorSerDe},
+            serializable_hob::{HobSerDe, MemoryTypeInfoEntrySerDe, ResourceDescriptorSerDe},
         },
     },
 };
@@ -279,6 +279,74 @@ impl<'a> HobValidator<'a> {
         }
         Ok(validation_report)
     }
+
+    /// Returns all Resource Descriptor HOBs whose owner is `MEMORY_TYPE_INFO_HOB_GUID`.
+    fn memory_type_info_resource_hobs(&self) -> Vec<&ResourceDescriptorSerDe> {
+        self.hob_list
+            .iter()
+            .filter_map(|hob| match hob {
+                HobSerDe::ResourceDescriptor(resource) | HobSerDe::ResourceDescriptorV2 { v1: resource, .. }
+                    if Self::is_memory_type_info(resource) =>
+                {
+                    Some(resource)
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Returns the parsed bin entries from the Memory Type Information GUID HOB, if present.
+    fn memory_type_info_entries(&self) -> Option<&[MemoryTypeInfoEntrySerDe]> {
+        self.hob_list.iter().find_map(|hob| match hob {
+            HobSerDe::MemoryTypeInformation { entries } => Some(entries.as_slice()),
+            _ => None,
+        })
+    }
+
+    /// Validates that at most one Resource Descriptor HOB owned by `MEMORY_TYPE_INFO_HOB_GUID`
+    /// exists. The DXE core rejects all such HOBs when multiple are present to avoid an
+    /// ambiguous bin-region selection. One violation is reported per discovered HOB.
+    fn validate_memory_type_info_single_resource_hob(&self) -> ValidationResult<'_> {
+        let mut validation_report = ValidationReport::new();
+        let hobs = self.memory_type_info_resource_hobs();
+        if hobs.len() > 1 {
+            for hob1 in hobs {
+                validation_report
+                    .add_violation(ValidationKind::Hob(HobValidationKind::MemoryTypeInfoMultipleResourceHobs { hob1 }));
+            }
+        }
+        Ok(validation_report)
+    }
+
+    /// Validates that the `ResourceLength` of the Memory Type Info Resource Descriptor HOB is
+    /// large enough to hold all bins reported in the Memory Type Information GUID HOB.
+    ///
+    /// The check only runs when exactly one Memory Type Info Resource Descriptor HOB is present
+    /// and a Memory Type Information GUID HOB has been captured.
+    fn validate_memory_type_info_resource_length(&self) -> ValidationResult<'_> {
+        let mut validation_report = ValidationReport::new();
+        let hobs = self.memory_type_info_resource_hobs();
+        let [resource] = hobs[..] else {
+            return Ok(validation_report);
+        };
+        let Some(entries) = self.memory_type_info_entries() else {
+            return Ok(validation_report);
+        };
+
+        let required_bytes: u64 =
+            entries.iter().map(|entry| entry.number_of_pages as u64 * UEFI_PAGE_SIZE as u64).sum();
+
+        if resource.resource_length < required_bytes {
+            validation_report.add_violation(ValidationKind::Hob(
+                HobValidationKind::MemoryTypeInfoResourceLengthTooSmall {
+                    hob1: resource,
+                    required_bytes,
+                    actual_bytes: resource.resource_length,
+                },
+            ));
+        }
+        Ok(validation_report)
+    }
 }
 
 impl Validator for HobValidator<'_> {
@@ -295,6 +363,8 @@ impl Validator for HobValidator<'_> {
         validation_report.append_report(self.validate_memory_uce_attribute()?);
         validation_report.append_report(self.validate_memory_cacheability_attribute()?);
         validation_report.append_report(self.validate_memory_cacheability_attribute_io_resource_hob()?);
+        validation_report.append_report(self.validate_memory_type_info_single_resource_hob()?);
+        validation_report.append_report(self.validate_memory_type_info_resource_length()?);
         Ok(validation_report)
     }
 }
@@ -681,5 +751,173 @@ mod tests {
         let result = validator.validate_overlapping_v1v2_attributes();
         assert!(result.is_ok());
         assert_eq!(result.unwrap().violation_count(), 1);
+    }
+
+    fn mem_type_info_hob(entries: Vec<MemoryTypeInfoEntrySerDe>) -> HobSerDe {
+        HobSerDe::MemoryTypeInformation { entries }
+    }
+
+    /// Exactly one Resource Descriptor HOB owned by `MEMORY_TYPE_INFO_HOB_GUID`
+    /// is the expected configuration and must not be flagged.
+    #[test]
+    fn test_single_memory_type_info_resource_hob_is_ok() {
+        let v1 = create_v1_hob(0x7e233000, 0xdbb000, 0, 0x7, &mem_info_owner());
+        let hob_list = vec![v1];
+
+        let validator = HobValidator::new(&hob_list);
+        let result = validator.validate_memory_type_info_single_resource_hob();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().violation_count(), 0);
+    }
+
+    /// A Memory Type Info HOB reported as a V2 Resource Descriptor HOB should be accepted
+    /// the same as a V1 Resource Descriptor HOB.
+    #[test]
+    fn test_single_memory_type_info_v2_resource_hob_is_ok() {
+        let v2 = create_v2_hob(0x7e233000, 0xdbb000, 0, 0x7, &mem_info_owner(), 0);
+        let hob_list = vec![v2];
+
+        let validator = HobValidator::new(&hob_list);
+        let result = validator.validate_memory_type_info_single_resource_hob();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().violation_count(), 0);
+    }
+
+    /// Zero Resource Descriptor HOBs owned by `MEMORY_TYPE_INFO_HOB_GUID` is
+    /// out of scope for this check.
+    #[test]
+    fn test_zero_memory_type_info_resource_hobs_is_ok() {
+        let v2 = create_v2_hob(0x100000, 0x1000, 0, 0x3c07, &zero_owner(), 0);
+        let hob_list = vec![v2];
+
+        let validator = HobValidator::new(&hob_list);
+        let result = validator.validate_memory_type_info_single_resource_hob();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().violation_count(), 0);
+    }
+
+    /// Multiple Resource Descriptor HOBs owned by `MEMORY_TYPE_INFO_HOB_GUID`
+    /// must each be reported as a violation.
+    #[test]
+    fn test_multiple_memory_type_info_resource_hobs_are_flagged() {
+        let v1a = create_v1_hob(0x7e233000, 0xdbb000, 0, 0x7, &mem_info_owner());
+        let v1b = create_v1_hob(0x90000000, 0x10000, 0, 0x7, &mem_info_owner());
+        let v1c = create_v1_hob(0xa0000000, 0x10000, 0, 0x7, &mem_info_owner());
+        let hob_list = vec![v1a, v1b, v1c];
+
+        let validator = HobValidator::new(&hob_list);
+        let result = validator.validate_memory_type_info_single_resource_hob();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().violation_count(), 3);
+    }
+
+    /// Multiple Memory Type Info Resource Descriptor HOBs are flagged regardless
+    /// of whether they are reported as V1 or V2 Resource Descriptor HOBs. A mix of the two
+    /// will report one violation per HOB.
+    #[test]
+    fn test_multiple_memory_type_info_mixed_v1_v2_resource_hobs_are_flagged() {
+        let v1 = create_v1_hob(0x7e233000, 0xdbb000, 0, 0x7, &mem_info_owner());
+        let v2 = create_v2_hob(0x90000000, 0x10000, 0, 0x7, &mem_info_owner(), 0);
+        let hob_list = vec![v1, v2];
+
+        let validator = HobValidator::new(&hob_list);
+        let result = validator.validate_memory_type_info_single_resource_hob();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().violation_count(), 2);
+    }
+
+    /// `ResourceLength` greater than the raw bin total must not be flagged.
+    #[test]
+    fn test_memory_type_info_resource_length_sufficient_is_ok() {
+        let v1 = create_v1_hob(0x7e000000, 0x100000, 0, 0x7, &mem_info_owner());
+        let mti = mem_type_info_hob(vec![
+            MemoryTypeInfoEntrySerDe { memory_type: 6, number_of_pages: 2 },
+            MemoryTypeInfoEntrySerDe { memory_type: 5, number_of_pages: 2 },
+        ]);
+        let hob_list = vec![v1, mti];
+
+        let validator = HobValidator::new(&hob_list);
+        let result = validator.validate_memory_type_info_resource_length();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().violation_count(), 0);
+    }
+
+    /// `ResourceLength` exactly equal to the raw bin total must not be flagged.
+    #[test]
+    fn test_memory_type_info_resource_length_exact_is_ok() {
+        let required = 4 * UEFI_PAGE_SIZE as u64;
+        let v1 = create_v1_hob(0x7e000000, required, 0, 0x7, &mem_info_owner());
+        let mti = mem_type_info_hob(vec![
+            MemoryTypeInfoEntrySerDe { memory_type: 6, number_of_pages: 2 },
+            MemoryTypeInfoEntrySerDe { memory_type: 5, number_of_pages: 2 },
+        ]);
+        let hob_list = vec![v1, mti];
+
+        let validator = HobValidator::new(&hob_list);
+        let result = validator.validate_memory_type_info_resource_length();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().violation_count(), 0);
+    }
+
+    /// `ResourceLength` smaller than the raw bin total must be flagged.
+    #[test]
+    fn test_memory_type_info_resource_length_too_small_is_flagged() {
+        let v1 = create_v1_hob(0x7e000000, 0x1000, 0, 0x7, &mem_info_owner());
+        let mti = mem_type_info_hob(vec![
+            MemoryTypeInfoEntrySerDe { memory_type: 6, number_of_pages: 5 },
+            MemoryTypeInfoEntrySerDe { memory_type: 5, number_of_pages: 5 },
+        ]);
+        let hob_list = vec![v1, mti];
+
+        let validator = HobValidator::new(&hob_list);
+        let result = validator.validate_memory_type_info_resource_length();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().violation_count(), 1);
+    }
+
+    /// The `ResourceLength` check applies to a Memory Type Info HOB reported as a
+    /// V2 Resource Descriptor HOB as well.
+    #[test]
+    fn test_memory_type_info_v2_resource_length_too_small_is_flagged() {
+        let v2 = create_v2_hob(0x7e000000, 0x1000, 0, 0x7, &mem_info_owner(), 0);
+        let mti = mem_type_info_hob(vec![
+            MemoryTypeInfoEntrySerDe { memory_type: 6, number_of_pages: 5 },
+            MemoryTypeInfoEntrySerDe { memory_type: 5, number_of_pages: 5 },
+        ]);
+        let hob_list = vec![v2, mti];
+
+        let validator = HobValidator::new(&hob_list);
+        let result = validator.validate_memory_type_info_resource_length();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().violation_count(), 1);
+    }
+
+    /// When no Memory Type Information GUID HOB is captured, the length check
+    /// is  skipped (since the required size cannot be determined).
+    #[test]
+    fn test_memory_type_info_resource_length_without_guid_hob_is_skipped() {
+        let v1 = create_v1_hob(0x7e000000, 0x1000, 0, 0x7, &mem_info_owner());
+        let hob_list = vec![v1];
+
+        let validator = HobValidator::new(&hob_list);
+        let result = validator.validate_memory_type_info_resource_length();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().violation_count(), 0);
+    }
+
+    /// When more than one Memory Type Info Resource Descriptor HOB is present,
+    /// the length check defers to the single instance check so a second violation
+    /// is not reported.
+    #[test]
+    fn test_memory_type_info_resource_length_with_multiple_hobs_is_skipped() {
+        let v1a = create_v1_hob(0x7e000000, 0x1000, 0, 0x7, &mem_info_owner());
+        let v1b = create_v1_hob(0x90000000, 0x1000, 0, 0x7, &mem_info_owner());
+        let mti = mem_type_info_hob(vec![MemoryTypeInfoEntrySerDe { memory_type: 6, number_of_pages: 100 }]);
+        let hob_list = vec![v1a, v1b, mti];
+
+        let validator = HobValidator::new(&hob_list);
+        let result = validator.validate_memory_type_info_resource_length();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().violation_count(), 0);
     }
 }

--- a/dxe_readiness_validator/src/validation_kind.rs
+++ b/dxe_readiness_validator/src/validation_kind.rs
@@ -224,9 +224,7 @@ impl PrettyPrintTable for ValidationKind<'_> {
                         serde_json::to_string_pretty(hob1).unwrap_or("hob 1 serialization failed!".to_string());
                     let v2_hob_column =
                         serde_json::to_string_pretty(hob2).unwrap_or("hob 2 serialization failed!".to_string());
-                    let resolution = if hob1.owner != hob2.owner {
-                        format!("hob 1 owner({}) do not match with hob 2 owner({})", hob1.owner, hob2.owner)
-                    } else if hob1.resource_attribute != hob2.resource_attribute {
+                    let resolution = if hob1.resource_attribute != hob2.resource_attribute {
                         format!(
                             "hob 1 resource_attribute({}) do not match with hob 2 resource_attribute({})",
                             hob1.resource_attribute, hob2.resource_attribute

--- a/dxe_readiness_validator/src/validation_kind.rs
+++ b/dxe_readiness_validator/src/validation_kind.rs
@@ -34,6 +34,12 @@ pub enum HobValidationKind<'a> {
 
     // V2 resource descriptor for io must have no cacheability or memory protection attributes set
     V2InvalidIoCacheabilityAttributes { hob1: &'a ResourceDescriptorSerDe, attributes: u64 },
+
+    // More than one Resource Descriptor HOB owned by gEfiMemoryTypeInformationGuid is present
+    MemoryTypeInfoMultipleResourceHobs { hob1: &'a ResourceDescriptorSerDe },
+
+    // Memory Type Info Resource Descriptor HOB ResourceLength is smaller than the sum of bin sizes
+    MemoryTypeInfoResourceLengthTooSmall { hob1: &'a ResourceDescriptorSerDe, required_bytes: u64, actual_bytes: u64 },
 }
 
 #[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -93,6 +99,12 @@ impl ValidationKind<'_> {
                 HobValidationKind::V2InvalidIoCacheabilityAttributes { .. } => {
                     "HOB: V2 Invalid IO Cacheability Attributes"
                 }
+                HobValidationKind::MemoryTypeInfoMultipleResourceHobs { .. } => {
+                    "HOB: Multiple Memory Type Info Resource Descriptor HOBs"
+                }
+                HobValidationKind::MemoryTypeInfoResourceLengthTooSmall { .. } => {
+                    "HOB: Memory Type Info Resource Descriptor HOB Length Too Small"
+                }
             },
             ValidationKind::Fv(fv) => match fv {
                 FvValidationKind::CombinedDriversPresent { .. } => "FV: Combined Drivers Present",
@@ -123,6 +135,11 @@ impl ValidationKind<'_> {
                                                                                      Ref: https://opendevicepartnership.github.io/patina/integrate/patina_dxe_core_requirements_checklist.html",
                 HobValidationKind::V2InvalidIoCacheabilityAttributes { .. } => "   Platforms must produce Resource Descriptor HOB v2s with no cacheability or memory protection\n   \
                                                                                    attributes set for IO resource types.",
+                HobValidationKind::MemoryTypeInfoMultipleResourceHobs { .. } => "   Only one Resource Descriptor HOB owned by the Memory Type Information GUID is allowed. ",
+                HobValidationKind::MemoryTypeInfoResourceLengthTooSmall { .. } => "   The Memory Type Info Resource Descriptor HOB's ResourceLength must be large enough\n   \
+                                                                                    to hold the sum of bin sizes reported in the Memory Type Information GUID HOB.\n   \
+                                                                                    Note: the check uses the raw page-count sum. Platforms may need additional space\n   \
+                                                                                    for per-bin alignment padding.",
             },
             ValidationKind::Fv(fv) => match fv {
                 FvValidationKind::CombinedDriversPresent { .. } => "   Firmware volume contains prohibited combined drivers. \nBelow file types are prohibited\n- COMBINED_MM_DXE(0x0C)\n- COMBINED_PEIM_DRIVER(0x08).\n   \
@@ -163,6 +180,12 @@ impl ValidationKind<'_> {
                 HobValidationKind::V2InvalidIoCacheabilityAttributes { .. } => {
                     "V2InvalidIoCacheabilityAttributes".to_string()
                 }
+                HobValidationKind::MemoryTypeInfoMultipleResourceHobs { .. } => {
+                    "MemoryTypeInfoMultipleResourceHobs".to_string()
+                }
+                HobValidationKind::MemoryTypeInfoResourceLengthTooSmall { .. } => {
+                    "MemoryTypeInfoResourceLengthTooSmall".to_string()
+                }
             },
             ValidationKind::Fv(fv) => match fv {
                 FvValidationKind::CombinedDriversPresent { .. } => "CombinedDriversPresent".to_string(),
@@ -200,6 +223,12 @@ impl PrettyPrintTable for ValidationKind<'_> {
                 }
                 HobValidationKind::V2InvalidIoCacheabilityAttributes { .. } => {
                     vec!["#", "V2 Hob", "Violation/Resolution"]
+                }
+                HobValidationKind::MemoryTypeInfoMultipleResourceHobs { .. } => {
+                    vec!["#", "Resource Descriptor Hob", "Violation/Resolution"]
+                }
+                HobValidationKind::MemoryTypeInfoResourceLengthTooSmall { .. } => {
+                    vec!["#", "Resource Descriptor Hob", "Violation/Resolution"]
                 }
             },
             ValidationKind::Fv(fv) => match fv {
@@ -294,6 +323,23 @@ impl PrettyPrintTable for ValidationKind<'_> {
                         attributes
                     );
                     vec![row_num, hob1_column, resolution]
+                }
+                HobValidationKind::MemoryTypeInfoMultipleResourceHobs { hob1 } => {
+                    let hob_column =
+                        serde_json::to_string_pretty(hob1).unwrap_or("hob serialization failed!".to_string());
+                    let resolution =
+                        "Only one Resource Descriptor HOB owned by\ngEfiMemoryTypeInformationGuid is allowed"
+                            .to_string();
+                    vec![row_num, hob_column, resolution]
+                }
+                HobValidationKind::MemoryTypeInfoResourceLengthTooSmall { hob1, required_bytes, actual_bytes } => {
+                    let hob_column =
+                        serde_json::to_string_pretty(hob1).unwrap_or("hob serialization failed!".to_string());
+                    let resolution = format!(
+                        "ResourceLength(0x{:X}) is smaller than the\nraw sum of bin sizes(0x{:X}) reported in\nthe Memory Type Information GUID HOB",
+                        actual_bytes, required_bytes
+                    );
+                    vec![row_num, hob_column, resolution]
                 }
             },
             ValidationKind::Fv(fv) => match fv {


### PR DESCRIPTION
## Description

**dxe_readiness_validator: Prevent false positives on PEI memory bin HOBs**

The validator was reporting "Inconsistent Memory Attributes" and
"V1MemoryRangeNotContainedInV2" against valid V1 resource
descriptor HOBs owned by `MEMORY_TYPE_INFO_HOB_GUID`. These describe
PEI memory bin ranges and are expected to overlap with (V2)
descriptors that report the underlying system memory for the bins.

The commit makes the following changes:

- Skip resource descriptors with owner == `MEMORY_TYPE_INFO_HOB_GUID`.
- Drop owner from the inconsistency predicate.
- Remove the leading owner branch from the `InconsistentMemoryAttributes`
  resolution message.

---

**dxe_readiness_validator: Add Memory Type Information HOB structural checks**

Resolves #87 

Adds two HOB validations for Memory Type Information HOBs:

1. Single Memory Type Info Owner Resource Descriptor HOB

   Reports a violation for every Resource Descriptor HOB owned by
   the Memory Type Info GUID beyond the first. The DXE core rejects
   multiple instances, so each redundant HOB is flagged individually.

2. `ResourceLength` sufficiency

   When exactly one Memory Type Info Owner Resource Descriptor HOB and
   a Memory Type Information GUID HOB are both captured, computes the
   sum of bin sizes and flags the resource HOB if `ResourceLength`
   is smaller.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- Boot QEMU Q35 with memory bins enabled and check that the readiness tool reports no errors

## Integration Instructions

- This change is backward compatible but also supports accounting for the Memory Type Info resource HOB produced for "PEI Memory Bins".