### PR TITLE
Migrate to R-EFI 6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aarch64-cpu"
-version = "10.0.0"
+version = "11.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a21cd0131c25c438e19cd6a774adf7e3f64f7f4d723022882facc2dee0f8bc9"
+checksum = "44171e22925ec72b63d86747bc3655c7849a5b8d865c980222128839f45ac034"
 dependencies = [
  "tock-registers",
 ]
@@ -81,9 +81,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
@@ -189,7 +189,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "document-features",
  "parking_lot",
@@ -393,9 +393,9 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mu_rust_helpers"
-version = "3.0.2"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028b489eb1f6ce61c83feee2cc5e8fb60978115a466c74b84b78aafed6041f34"
+checksum = "8f0939baed11fd68187c2fd292ee166944cdd8472bc8cf261b08e3cbd568d9d6"
 dependencies = [
  "mu_uefi_decompress",
  "mu_uefi_guid",
@@ -404,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "mu_uefi_decompress"
-version = "3.0.2"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b85df261b0b0241dee3c95a186fac29234b0e60bfabef7d57d3099ec2b7cb6"
+checksum = "5592026864b59cc927a2f42ad2721b9820271d6f70ba2e20a796621eb688389f"
 dependencies = [
  "bitvec",
  "log",
@@ -414,9 +414,9 @@ dependencies = [
 
 [[package]]
 name = "mu_uefi_guid"
-version = "3.0.2"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091e08bf3b952c68a5d3915d53b4221dc41fad3e00d3eb2020d2dd46f83ae5e2"
+checksum = "392e8c601a9cc36a519c61063a3250e55a3b049a85ee314e49b8a1ad09ff70c3"
 dependencies = [
  "r-efi",
  "uuid",
@@ -424,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "mu_uefi_perf_timer"
-version = "3.0.2"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df471d72676adaa480d61a0c9ed30a844a90842f876c188a0b30cb760d2444aa"
+checksum = "4819bbf728631dd84bc2511c5c3551687db00830998e4937a0ff7af33a591b15"
 dependencies = [
  "aarch64-cpu",
  "log",
@@ -484,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "patina"
-version = "21.2.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d833081e3ce92ce59e31e0f851c71b7d7007e20336317984478f20d99630e90"
+checksum = "61ed5c35d03fb46d6b3049dff0eb7a78b8a8b3cfce09fe0e3627ad234d3fc3cb"
 dependencies = [
  "cfg-if",
  "compile-time",
@@ -513,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "patina_macro"
-version = "21.2.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129ea044e9ccf6121023fab8479ab3ee8f01b474eebba0053a256fd6cd6878b5"
+checksum = "0a74965ff8c18ef45a3dad49fba8fb84e58427200b28375783799a4759e8f3f4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -525,9 +525,9 @@ dependencies = [
 
 [[package]]
 name = "patina_stacktrace"
-version = "21.2.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39da5dabd54e8d0771c8f495f412279eeff8fb2b1c41c3e72a4806993ec04475"
+checksum = "2b77dcd920470e59372f09d40186ea7040930ef62211cd9f5bdeb0e3c59dc7db"
 dependencies = [
  "cfg-if",
  "log",
@@ -585,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -610,7 +610,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -628,7 +628,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -814,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "tock-registers"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b9e2fdb3a1e862c0661768b7ed25390811df1947a8acbfbefe09b47078d93c4"
+checksum = "8d2d250f87fb3fb6f225c907cf54381509f47b40b74b1d1f12d2dccbc915bdfe"
 
 [[package]]
 name = "uart_16550"
@@ -824,7 +824,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e492212ac378a5e00da953718dafb1340d9fbaf4f27d6f3c5cab03d931d1c049"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "rustversion",
  "x86",
 ]
@@ -844,7 +844,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66ab9569afdd1e33a31d8002343aa1df594f055347b1a66136bf9dd6cbc3ec37"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "log",
  "ptr_meta",
@@ -871,7 +871,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3775e5934877acaef4b00f254f252df1e2266903c31e51455c117f4f2824eda"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "uguid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,23 @@ description = "Dxe Readiness Capture/Validation Tool"
 repository = "https://github.com/OpenDevicePartnership/patina-readiness-tool"
 
 [workspace.dependencies]
+
+# Patina Dependencies
+patina = { version = "22", features = ["serde"] }
+patina_stacktrace = { version = "22" }
+
+# Other Dependencies
 cfg-if = "1.0.4"
+clap = { version = "4", features = ["derive"] }
 goblin = { version = "0.10.7", default-features = false }
-patina = { version = "21", features = ["serde"] }
-patina_stacktrace = { version = "21" }
 log = { version = "^0.4", default-features = false, features = [
   "release_max_level_warn",
 ] }
+r-efi = { version = "^6", default-features = false }
 spin = "^0.12.0"
 serde = { version = "1", default-features = false, features = [
   "alloc",
   "derive",
 ] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
-r-efi = { version = "5.3.0", default-features = false }
 uuid = { version = "1.23", default-features = false }
-clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
## Description

This PR consumes the major branch changes done in Patina as part of R-EFI 6.0 migration(release as version 22).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

`cargo make all`

## Integration Instructions

Will merge this once https://github.com/OpenDevicePartnership/patina/pull/1548 is merged and patina release 22 is made. 