### PR TITLE
Validator: Add summary of HOBs and FVs parsed to the validation report

### DIFF
--- a/dxe_readiness_validator/src/validate.rs
+++ b/dxe_readiness_validator/src/validate.rs
@@ -61,11 +61,17 @@ impl ValidationApp {
 
         let hob_validator = HobValidator::new(&data.hob_list);
         validation_report.add_summary(hob_validator.summary());
-        validation_report.append_report(hob_validator.validate()?);
+
+        if let Ok(report) = hob_validator.validate() {
+            validation_report.append_report(report);
+        }
 
         let fv_validator = FvValidator::new(&data.fv_list);
         validation_report.add_summary(fv_validator.summary());
-        validation_report.append_report(fv_validator.validate()?);
+
+        if let Ok(report) = fv_validator.validate() {
+            validation_report.append_report(report);
+        }
 
         validation_report.show_results();
 
@@ -159,17 +165,24 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_empty_hob_list_propagates() {
+    fn test_validate_empty_hob_list_is_ok() {
         let data = DxeReadinessCaptureSerDe { hob_list: vec![], fv_list: vec![clean_fv()] };
         let app = app_with_data(Some(data));
-        assert_eq!(app.validate().unwrap_err(), ValidationAppError::EmptyHobList);
+        assert!(app.validate().is_ok());
     }
 
     #[test]
-    fn test_validate_empty_fv_list_propagates() {
+    fn test_validate_empty_fv_list_is_ok() {
         let data = DxeReadinessCaptureSerDe { hob_list: vec![clean_v2_hob()], fv_list: vec![] };
         let app = app_with_data(Some(data));
-        assert_eq!(app.validate().unwrap_err(), ValidationAppError::EmptyFvList);
+        assert!(app.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_empty_hob_and_fv_lists_is_ok() {
+        let data = DxeReadinessCaptureSerDe { hob_list: vec![], fv_list: vec![] };
+        let app = app_with_data(Some(data));
+        assert!(app.validate().is_ok());
     }
 
     #[test]

--- a/dxe_readiness_validator/src/validate.rs
+++ b/dxe_readiness_validator/src/validate.rs
@@ -60,9 +60,11 @@ impl ValidationApp {
         let mut validation_report = ValidationReport::new();
 
         let hob_validator = HobValidator::new(&data.hob_list);
+        validation_report.add_summary(hob_validator.summary());
         validation_report.append_report(hob_validator.validate()?);
 
         let fv_validator = FvValidator::new(&data.fv_list);
+        validation_report.add_summary(fv_validator.summary());
         validation_report.append_report(fv_validator.validate()?);
 
         validation_report.show_results();
@@ -73,5 +75,133 @@ impl ValidationApp {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use patina::pi::serializable::{
+        serializable_fv::FirmwareVolumeSerDe,
+        serializable_hob::{HobSerDe, ResourceDescriptorSerDe},
+    };
+    use r_efi::efi;
+
+    fn app_with_data(data: Option<DxeReadinessCaptureSerDe>) -> ValidationApp {
+        ValidationApp { args: CommandLine { filename: None }, data }
+    }
+
+    fn app_with_file(filename: Option<String>) -> ValidationApp {
+        ValidationApp { args: CommandLine { filename }, data: None }
+    }
+
+    fn temp_path(name: &str) -> String {
+        let mut path = std::env::temp_dir();
+        path.push(format!("dxe_val_test_{}_{name}", std::process::id()));
+        path.to_string_lossy().to_string()
+    }
+
+    /// A V2 resource descriptor with a valid single cacheability attribute that
+    /// passes all HOB checks.
+    fn clean_v2_hob() -> HobSerDe {
+        HobSerDe::ResourceDescriptorV2 {
+            v1: ResourceDescriptorSerDe {
+                owner: "owner".to_string(),
+                resource_type: 3,
+                resource_attribute: 0,
+                physical_start: 0x100000,
+                resource_length: 0x1000,
+            },
+            attributes: efi::MEMORY_UC,
+        }
+    }
+
+    /// A lone V1 resource descriptor with no covering V2, which triggers exactly
+    /// one violation.
+    fn lone_v1_hob() -> HobSerDe {
+        HobSerDe::ResourceDescriptor(ResourceDescriptorSerDe {
+            owner: "owner".to_string(),
+            resource_type: 3,
+            resource_attribute: 0,
+            physical_start: 0x100000,
+            resource_length: 0x1000,
+        })
+    }
+
+    fn clean_fv() -> FirmwareVolumeSerDe {
+        FirmwareVolumeSerDe {
+            fv_name: "FvMain".to_string(),
+            fv_length: 1024,
+            fv_base_address: 0x1000,
+            fv_attributes: 0,
+            files: vec![],
+        }
+    }
+
+    #[test]
+    fn test_validate_none_data_errors() {
+        let app = app_with_data(None);
+        assert_eq!(app.validate().unwrap_err(), ValidationAppError::EmptyHobList);
+    }
+
+    #[test]
+    fn test_validate_clean_data_ok() {
+        let data = DxeReadinessCaptureSerDe { hob_list: vec![clean_v2_hob()], fv_list: vec![clean_fv()] };
+        let app = app_with_data(Some(data));
+        assert!(app.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_reports_violations() {
+        let data = DxeReadinessCaptureSerDe { hob_list: vec![lone_v1_hob()], fv_list: vec![clean_fv()] };
+        let app = app_with_data(Some(data));
+        assert_eq!(app.validate().unwrap_err(), ValidationAppError::ValidationErrors(1));
+    }
+
+    #[test]
+    fn test_validate_empty_hob_list_propagates() {
+        let data = DxeReadinessCaptureSerDe { hob_list: vec![], fv_list: vec![clean_fv()] };
+        let app = app_with_data(Some(data));
+        assert_eq!(app.validate().unwrap_err(), ValidationAppError::EmptyHobList);
+    }
+
+    #[test]
+    fn test_validate_empty_fv_list_propagates() {
+        let data = DxeReadinessCaptureSerDe { hob_list: vec![clean_v2_hob()], fv_list: vec![] };
+        let app = app_with_data(Some(data));
+        assert_eq!(app.validate().unwrap_err(), ValidationAppError::EmptyFvList);
+    }
+
+    #[test]
+    fn test_parse_json_missing_filename_errors() {
+        let mut app = app_with_file(None);
+        assert!(matches!(app.parse_json(), Err(ValidationAppError::InvalidCommandLine(_))));
+    }
+
+    #[test]
+    fn test_parse_json_file_not_found() {
+        let mut app = app_with_file(Some(temp_path("does_not_exist.json")));
+        assert!(matches!(app.parse_json(), Err(ValidationAppError::JSONFileNotFound(_))));
+    }
+
+    #[test]
+    fn test_parse_json_invalid_content() {
+        let path = temp_path("invalid.json");
+        fs::write(&path, "not valid json").unwrap();
+        let mut app = app_with_file(Some(path.clone()));
+        let result = app.parse_json();
+        let _ = fs::remove_file(&path);
+        assert!(matches!(result, Err(ValidationAppError::JSONSerializationFailed(..))));
+    }
+
+    #[test]
+    fn test_parse_json_valid_content() {
+        let path = temp_path("valid.json");
+        fs::write(&path, r#"{"hob_list": [], "fv_list": []}"#).unwrap();
+        let mut app = app_with_file(Some(path.clone()));
+        let result = app.parse_json();
+        let _ = fs::remove_file(&path);
+        assert!(result.is_ok());
+        assert!(app.data.is_some());
     }
 }

--- a/dxe_readiness_validator/src/validate/fv.rs
+++ b/dxe_readiness_validator/src/validate/fv.rs
@@ -173,6 +173,15 @@ impl Validator for FvValidator<'_> {
         validation_report.append_report(self.validate_fv_for_apriori_file()?);
         Ok(validation_report)
     }
+
+    fn summary(&self) -> String {
+        let total = self.fv_list.len();
+        let mut summary = format!("FV Summary:\n  Total FVs: {total}");
+        for fv in self.fv_list {
+            summary.push_str(&format!("\n    {}", fv.fv_name));
+        }
+        summary
+    }
 }
 
 #[cfg(test)]
@@ -539,5 +548,39 @@ mod tests {
         let result = validator.validate();
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), ValidationAppError::EmptyFvList);
+    }
+
+    #[test]
+    fn test_fv_summary_lists_count_and_names() {
+        let fv_list = vec![
+            FirmwareVolumeSerDe {
+                fv_name: "FvMain".to_string(),
+                fv_length: 1024,
+                fv_base_address: 0x1000,
+                fv_attributes: 0,
+                files: vec![],
+            },
+            FirmwareVolumeSerDe {
+                fv_name: "FvBoot".to_string(),
+                fv_length: 2048,
+                fv_base_address: 0x2000,
+                fv_attributes: 0,
+                files: vec![],
+            },
+        ];
+
+        let validator = FvValidator::new(&fv_list);
+        let summary = validator.summary();
+        assert!(summary.contains("Total FVs: 2"), "got: {summary}");
+        assert!(summary.contains("FvMain"), "got: {summary}");
+        assert!(summary.contains("FvBoot"), "got: {summary}");
+    }
+
+    #[test]
+    fn test_fv_summary_empty_list() {
+        let fv_list = vec![];
+        let validator = FvValidator::new(&fv_list);
+        let summary = validator.summary();
+        assert!(summary.contains("Total FVs: 0"), "got: {summary}");
     }
 }

--- a/dxe_readiness_validator/src/validate/fv.rs
+++ b/dxe_readiness_validator/src/validate/fv.rs
@@ -175,6 +175,10 @@ impl Validator for FvValidator<'_> {
     }
 
     fn summary(&self) -> String {
+        if self.fv_list.is_empty() {
+            return "No FVs to validate.".to_string();
+        }
+
         let total = self.fv_list.len();
         let mut summary = format!("FV Summary:\n  Total FVs: {total}");
         for fv in self.fv_list {
@@ -580,7 +584,7 @@ mod tests {
     fn test_fv_summary_empty_list() {
         let fv_list = vec![];
         let validator = FvValidator::new(&fv_list);
-        let summary = validator.summary();
-        assert!(summary.contains("Total FVs: 0"), "got: {summary}");
+
+        assert_eq!(validator.summary(), "No FVs to validate.");
     }
 }

--- a/dxe_readiness_validator/src/validate/hob.rs
+++ b/dxe_readiness_validator/src/validate/hob.rs
@@ -368,6 +368,10 @@ impl Validator for HobValidator<'_> {
     }
 
     fn summary(&self) -> String {
+        if self.hob_list.is_empty() {
+            return "No HOBs to validate.".to_string();
+        }
+
         let mut counts: std::collections::BTreeMap<&str, usize> = std::collections::BTreeMap::new();
         for hob in self.hob_list {
             let kind = match hob {
@@ -972,5 +976,13 @@ mod tests {
         assert!(summary.contains("Total HOBs: 1"), "got: {summary}");
         assert!(summary.contains("ResourceDescriptor (V1): 1"), "got: {summary}");
         assert!(!summary.contains("MemoryAllocation"), "got: {summary}");
+    }
+
+    #[test]
+    fn test_hob_summary_empty_list() {
+        let hob_list = vec![];
+        let validator = HobValidator::new(&hob_list);
+
+        assert_eq!(validator.summary(), "No HOBs to validate.");
     }
 }

--- a/dxe_readiness_validator/src/validate/hob.rs
+++ b/dxe_readiness_validator/src/validate/hob.rs
@@ -366,6 +366,30 @@ impl Validator for HobValidator<'_> {
         validation_report.append_report(self.validate_memory_type_info_resource_length()?);
         Ok(validation_report)
     }
+
+    fn summary(&self) -> String {
+        let mut counts: std::collections::BTreeMap<&str, usize> = std::collections::BTreeMap::new();
+        for hob in self.hob_list {
+            let kind = match hob {
+                HobSerDe::Handoff { .. } => "Handoff",
+                HobSerDe::MemoryAllocation { .. } => "MemoryAllocation",
+                HobSerDe::ResourceDescriptor(_) => "ResourceDescriptor (V1)",
+                HobSerDe::ResourceDescriptorV2 { .. } => "ResourceDescriptorV2 (V2)",
+                HobSerDe::GuidExtension { .. } => "GuidExtension",
+                HobSerDe::MemoryTypeInformation { .. } => "MemoryTypeInformation",
+                HobSerDe::FirmwareVolume { .. } => "FirmwareVolume",
+                HobSerDe::Cpu { .. } => "Cpu",
+                HobSerDe::UnknownHob => "UnknownHob",
+            };
+            *counts.entry(kind).or_default() += 1;
+        }
+
+        let mut summary = format!("HOB Summary:\n  Total HOBs: {}", self.hob_list.len());
+        for (kind, count) in counts {
+            summary.push_str(&format!("\n    {kind}: {count}"));
+        }
+        summary
+    }
 }
 
 #[cfg(test)]
@@ -918,5 +942,35 @@ mod tests {
         let result = validator.validate_memory_type_info_resource_length();
         assert!(result.is_ok());
         assert_eq!(result.unwrap().violation_count(), 0);
+    }
+
+    #[test]
+    fn test_hob_summary_counts_each_type() {
+        let hob_list = vec![
+            create_v1_hob(0x1000, 0x1000, 3, 0, "owner1"),
+            create_v1_hob(0x3000, 0x1000, 3, 0, "owner1"),
+            create_v2_hob(0x5000, 0x1000, 3, 0, "owner1", 123),
+            create_memory_hob("mem".to_string(), 0x10000, 0x1000, 1),
+            mem_type_info_hob(vec![MemoryTypeInfoEntrySerDe { memory_type: 6, number_of_pages: 1 }]),
+        ];
+
+        let validator = HobValidator::new(&hob_list);
+        let summary = validator.summary();
+        assert!(summary.contains("Total HOBs: 5"), "got: {summary}");
+        assert!(summary.contains("ResourceDescriptor (V1): 2"), "got: {summary}");
+        assert!(summary.contains("ResourceDescriptorV2 (V2): 1"), "got: {summary}");
+        assert!(summary.contains("MemoryAllocation: 1"), "got: {summary}");
+        assert!(summary.contains("MemoryTypeInformation: 1"), "got: {summary}");
+    }
+
+    #[test]
+    fn test_hob_summary_omits_absent_types() {
+        let hob_list = vec![create_v1_hob(0x1000, 0x1000, 3, 0, "owner1")];
+
+        let validator = HobValidator::new(&hob_list);
+        let summary = validator.summary();
+        assert!(summary.contains("Total HOBs: 1"), "got: {summary}");
+        assert!(summary.contains("ResourceDescriptor (V1): 1"), "got: {summary}");
+        assert!(!summary.contains("MemoryAllocation"), "got: {summary}");
     }
 }

--- a/dxe_readiness_validator/src/validation_report.rs
+++ b/dxe_readiness_validator/src/validation_report.rs
@@ -17,11 +17,17 @@ use crate::validation_kind::ValidationKind;
 pub struct ValidationReport<'a> {
     // Report is a BTreeMap of Group name and list of violations
     report: BTreeMap<String, Vec<ValidationKind<'a>>>,
+    // Human-readable summaries of the validated data.
+    summaries: Vec<String>,
 }
 
 impl<'a> ValidationReport<'a> {
     pub fn new() -> Self {
-        Self { report: BTreeMap::new() }
+        Self { report: BTreeMap::new(), summaries: Vec::new() }
+    }
+
+    pub fn add_summary(&mut self, summary: String) {
+        self.summaries.push(summary);
     }
 
     pub fn add_violation(&mut self, validation: ValidationKind<'a>) {
@@ -31,6 +37,7 @@ impl<'a> ValidationReport<'a> {
 
     pub fn append_report(&mut self, mut validation_report: ValidationReport<'a>) {
         self.report.append(&mut validation_report.report);
+        self.summaries.append(&mut validation_report.summaries);
     }
 
     pub fn violation_count(&self) -> usize {
@@ -38,6 +45,13 @@ impl<'a> ValidationReport<'a> {
     }
 
     pub fn show_results(&self) {
+        for summary in &self.summaries {
+            println!("{}", summary.cyan().bold());
+            println!();
+        }
+
+        println!();
+
         if self.report.is_empty() {
             println!("No violations found.");
         } else {
@@ -47,6 +61,7 @@ impl<'a> ValidationReport<'a> {
 
     fn pretty_print(&self) {
         println!("{}", "Validation Results:".red().bold());
+
         for violations in self.report.values() {
             if violations.is_empty() {
                 continue;
@@ -67,5 +82,98 @@ impl<'a> ValidationReport<'a> {
             println!("{table}");
             println!("💡 {}", format!("Guidance:\n{}", violations.first().unwrap().guidance()).blue().bold());
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::validation_kind::HobValidationKind;
+    use patina::pi::serializable::serializable_hob::ResourceDescriptorSerDe;
+
+    fn resource(start: u64, length: u64) -> ResourceDescriptorSerDe {
+        ResourceDescriptorSerDe {
+            owner: "owner".to_string(),
+            resource_type: 0,
+            resource_attribute: 0,
+            physical_start: start,
+            resource_length: length,
+        }
+    }
+
+    #[test]
+    fn test_add_summary_stores_in_order() {
+        let mut report = ValidationReport::new();
+        report.add_summary("HOB Summary".to_string());
+        report.add_summary("FV Summary".to_string());
+
+        assert_eq!(report.summaries, vec!["HOB Summary".to_string(), "FV Summary".to_string()]);
+    }
+
+    #[test]
+    fn test_append_report_merges_summaries() {
+        let mut base = ValidationReport::new();
+        base.add_summary("HOB Summary".to_string());
+
+        let mut other = ValidationReport::new();
+        other.add_summary("FV Summary".to_string());
+
+        base.append_report(other);
+
+        assert_eq!(base.summaries, vec!["HOB Summary".to_string(), "FV Summary".to_string()]);
+    }
+
+    #[test]
+    fn test_new_report_has_no_summaries() {
+        let report = ValidationReport::new();
+        assert!(report.summaries.is_empty());
+    }
+
+    #[test]
+    fn test_add_violation_and_count() {
+        let r1 = resource(0x1000, 0x1000);
+        let r2 = resource(0x1800, 0x1000);
+
+        let mut report = ValidationReport::new();
+        assert_eq!(report.violation_count(), 0);
+
+        report.add_violation(ValidationKind::Hob(HobValidationKind::OverlappingMemoryRanges { hob1: &r1, hob2: &r2 }));
+        report.add_violation(ValidationKind::Hob(HobValidationKind::V1MemoryRangeNotContainedInV2 { hob1: &r1 }));
+
+        assert_eq!(report.violation_count(), 2);
+    }
+
+    #[test]
+    fn test_append_report_merges_violations() {
+        let r1 = resource(0x1000, 0x1000);
+        let mut base = ValidationReport::new();
+
+        let mut other = ValidationReport::new();
+        other.add_violation(ValidationKind::Hob(HobValidationKind::V1MemoryRangeNotContainedInV2 { hob1: &r1 }));
+
+        base.append_report(other);
+        assert_eq!(base.violation_count(), 1);
+    }
+
+    #[test]
+    fn test_show_results_with_violations() {
+        let r1 = resource(0x1000, 0x1000);
+        let r2 = resource(0x1800, 0x1000);
+
+        let mut report = ValidationReport::new();
+        report.add_summary("HOB Summary".to_string());
+        report.add_violation(ValidationKind::Hob(HobValidationKind::OverlappingMemoryRanges { hob1: &r1, hob2: &r2 }));
+
+        // Exercises the pretty_print path.
+        report.show_results();
+    }
+
+    #[test]
+    fn test_show_results_without_violations() {
+        let mut report = ValidationReport::new();
+        report.add_summary("HOB Summary".to_string());
+
+        // Exercises the "No violations found" path.
+        report.show_results();
     }
 }

--- a/dxe_readiness_validator/src/validator.rs
+++ b/dxe_readiness_validator/src/validator.rs
@@ -16,4 +16,7 @@ use crate::validate::ValidationResult;
 pub trait Validator {
     /// Executes the validation logic and returns a [`ValidationResult`] object.
     fn validate(&self) -> ValidationResult<'_>;
+
+    /// Returns a human-readable summary of the data being validated.
+    fn summary(&self) -> String;
 }


### PR DESCRIPTION
## Description

- Add summary header before the validation results. Otherwise, it is hard to comparand the violations wrt overall hobs/fvs. 
```
HOB Summary:
  Total HOBs: 997
    Cpu: 1
    FirmwareVolume: 5
    GuidExtension: 169
    Handoff: 1
    MemoryAllocation: 158
    MemoryTypeInformation: 1
    ResourceDescriptor (V1): 37
    UnknownHob: 625

FV Summary:
  Total FVs: 5
    b73fe497-b92e-416e-8326-45ad0d270091
    1b5c27fe-f01c-4fbc-aeae-341b2e992a17
    00000000-0000-0000-0000-000000000000
    a881d567-6cb0-4eee-8435-2e72d33e45b5
    2fd7cb74-ef58-4f4a-9b33-64992632d228

Validation Results:
```

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validated with results from a physical platform.

## Integration Instructions

NA