### PR TITLE
Validator: Skip Memory Type Info HOB in memory overlap check

### DIFF
--- a/dxe_readiness_validator/src/validate/hob.rs
+++ b/dxe_readiness_validator/src/validate/hob.rs
@@ -66,6 +66,10 @@ impl<'a> HobValidator<'a> {
     /// Checks for overlapping address ranges in memory and I/O resource
     /// descriptor HOBs. Reports each overlapping pair as a validation
     /// violation.
+    ///
+    /// Resource descriptors whose `owner` is `MEMORY_TYPE_INFO_HOB_GUID` are
+    /// skipped because the PEI memory bin HOB is expected to overlap with the
+    /// resource descriptors describing the system memory backing those bins.
     fn validate_memory_overlap(&self) -> ValidationResult<'_> {
         let mut validation_report = ValidationReport::new();
         let mut overlaps = Vec::new();
@@ -76,6 +80,11 @@ impl<'a> HobValidator<'a> {
 
         for hob in self.hob_list {
             match hob {
+                // The Memory Type Information (PEI memory bins) resource descriptor HOB is expected
+                // to overlap the system-memory resource descriptor that backs the bins, so exclude
+                // it from the overlap check. See DXE Core CoreInitializeMemoryServices.
+                HobSerDe::ResourceDescriptor(resource) if Self::is_memory_type_info(resource) => (),
+                HobSerDe::ResourceDescriptorV2 { v1: resource, .. } if Self::is_memory_type_info(resource) => (),
                 HobSerDe::ResourceDescriptor(resource) if !Self::is_io(resource.resource_type) => {
                     v1_memory_hobs.push(resource)
                 }
@@ -458,6 +467,47 @@ mod tests {
         assert!(result.is_ok());
         let validation_report = result.unwrap();
         assert_eq!(validation_report.violation_count(), 0);
+    }
+
+    #[test]
+    fn test_memory_type_info_v1_overlap_within_system_memory_is_not_flagged() {
+        // The Memory Type Information bin HOB is carved out of the system memory
+        // resource descriptor, so its range is contained within it. This overlap
+        // is expected and must not be flagged.
+        let system_memory = create_v1_hob(0x5b23c000, 0x14dc4000, 0, 0x3c07, &zero_owner());
+        let mem_type_info = create_v1_hob(0x6e439000, 0xdc4000, 0, 0x7, &mem_info_owner());
+        let hob_list = vec![system_memory, mem_type_info];
+
+        let validator = HobValidator::new(&hob_list);
+        let result = validator.validate_memory_overlap();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().violation_count(), 0);
+    }
+
+    #[test]
+    fn test_memory_type_info_v2_overlap_within_system_memory_is_not_flagged() {
+        let system_memory = create_v2_hob(0x5b23c000, 0x14dc4000, 0, 0x3c07, &zero_owner(), 0);
+        let mem_type_info = create_v2_hob(0x6e439000, 0xdc4000, 0, 0x7, &mem_info_owner(), 0);
+        let hob_list = vec![system_memory, mem_type_info];
+
+        let validator = HobValidator::new(&hob_list);
+        let result = validator.validate_memory_overlap();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().violation_count(), 0);
+    }
+
+    #[test]
+    fn test_non_memory_type_info_overlap_is_still_flagged() {
+        // Two overlapping system-memory HOBs that are not the Memory Type
+        // Information bin HOB must still be reported.
+        let hob1 = create_v1_hob(0x5b23c000, 0x14dc4000, 0, 0x3c07, &zero_owner());
+        let hob2 = create_v1_hob(0x6e439000, 0xdc4000, 0, 0x3c07, "owner-x");
+        let hob_list = vec![hob1, hob2];
+
+        let validator = HobValidator::new(&hob_list);
+        let result = validator.validate_memory_overlap();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().violation_count(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Description

The PEI memory bin (Memory Type Info) resource descriptor is expected to
overlap the system memory descriptor backing it, so exclude owners of
MEMORY_TYPE_INFO_HOB_GUID from validate_memory_overlap.

Fixes below false positive:
```
❌ HOB: Overlapping Memory Ranges
┌───┬────────────────────────────────────────────────────┬────────────────────────────────────────────────────┬───────────────────────────────────────────────────────────────────────────┐
│ # ┆ Hob 1                                              ┆ Hob 2                                              ┆ Violation/Resolution                                                      │
╞═══╪════════════════════════════════════════════════════╪════════════════════════════════════════════════════╪═══════════════════════════════════════════════════════════════════════════╡
│ 1 ┆ {                                                  ┆ {                                                  ┆ Hob 1 range should not overlap with Hob 2 range                           │
│   ┆   "owner": "00000000-0000-0000-0000-000000000000", ┆   "owner": "4c19049f-4137-4dd3-9c10-8b97a83ffdfa", ┆ Hob 1 range(0x5b23c000, 0x70000000) | Hob 2 range(0x6e439000, 0x6f1fd000) │
│   ┆   "resource_type": 0,                              ┆   "resource_type": 0,                              ┆                                                                           │
│   ┆   "resource_attribute": "0x3c07",                  ┆   "resource_attribute": "0x7",                     ┆                                                                           │
│   ┆   "physical_start": "0x5b23c000",                  ┆   "physical_start": "0x6e439000",                  ┆                                                                           │
│   ┆   "resource_length": "0x14dc4000"                  ┆   "resource_length": "0xdc4000"                    ┆                                                                           │
│   ┆ }                                                  ┆ }                                                  ┆                                                                           │
└───┴────────────────────────────────────────────────────┴────────────────────────────────────────────────────┴───────────────────────────────────────────────────────────────────────────┘
```

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validated with a physical platform capture json file.

## Integration Instructions

NA